### PR TITLE
Multi mints

### DIFF
--- a/plutarch-context-builder.cabal
+++ b/plutarch-context-builder.cabal
@@ -13,7 +13,9 @@ license:
 
 -- license-file:       LICENSE
 author:             Koz Ross, Seungheon Oh
-maintainer:         Koz Ross <koz@mlabs.city>, Seungheon Oh <seungheon.ooh@gmail.com>   
+maintainer:
+  Koz Ross <koz@mlabs.city>, Seungheon Oh <seungheon.ooh@gmail.com>   
+
 copyright:          (C) 2022 Liqwid Labs
 category:           Plutarch
 build-type:         Simple
@@ -100,7 +102,7 @@ library
   hs-source-dirs:  src
 
 -- Tests
-   
+
 test-suite sample
   import:         common-tests
   type:           exitcode-stdio-1.0

--- a/plutarch-context-builder.cabal
+++ b/plutarch-context-builder.cabal
@@ -107,6 +107,5 @@ test-suite sample
   import:         common-tests
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
-  other-modules:
-    MintingBuilder
+  other-modules:  MintingBuilder
   hs-source-dirs: sample/

--- a/plutarch-context-builder.cabal
+++ b/plutarch-context-builder.cabal
@@ -107,4 +107,6 @@ test-suite sample
   import:         common-tests
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
+  other-modules:
+    MintingBuilder
   hs-source-dirs: sample/

--- a/sample/Main.hs
+++ b/sample/Main.hs
@@ -1,29 +1,31 @@
 module Main (main) where
 
 import GHC.IO.Encoding
+import qualified MintingBuilder
 import Plutarch.Context
 import PlutusLedgerApi.V1
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.HUnit ((@?=), testCase)
-import qualified MintingBuilder
-
+import Test.Tasty.HUnit (testCase, (@?=))
 
 main :: IO ()
 main = do
     setLocaleEncoding utf8
     defaultMain . testGroup "Sample Tests" $
-      [ testCase "TxInfo matches with both Minting and Spending Script Purposes" $
-          (scriptContextTxInfo <$> a) @?= (scriptContextTxInfo <$> b)
-      , MintingBuilder.specs
-      ]
-      where
-        a = buildMinting generalSample{ mbMintingCS = Just "aaaa" }
-        b = buildSpending
-          (generalSample <> withSpending
-            (pubKey "aabb" . withValue (singleton "cc" "hello" 123)))
+        [ testCase "TxInfo matches with both Minting and Spending Script Purposes" $
+            (scriptContextTxInfo <$> a) @?= (scriptContextTxInfo <$> b)
+        , MintingBuilder.specs
+        ]
+  where
+    a = buildMinting generalSample{mbMintingCS = Just "aaaa"}
+    b =
+        buildSpending
+            ( generalSample
+                <> withSpending
+                    (pubKey "aabb" . withValue (singleton "cc" "hello" 123))
+            )
 
 generalSample :: (Monoid a, Builder a) => a
-generalSample  =
+generalSample =
     mconcat
         [ input $
             pubKey "aabb"

--- a/sample/MintingBuilder.hs
+++ b/sample/MintingBuilder.hs
@@ -1,0 +1,42 @@
+module MintingBuilder (specs) where
+
+import Test.Tasty (TestTree, testGroup)
+import Plutarch.Context (mint, buildMinting, MintingBuilder (mbMintingCS))
+import Test.Tasty.HUnit (testCase, assertFailure)
+
+import qualified PlutusLedgerApi.V1.Value as Value
+
+
+specs :: TestTree
+specs = testGroup "Minting Builder Unit Tests"
+  [ testCase "MintingBuilder succeeds with single input" $
+      case buildMinting singleMint{ mbMintingCS = Just "deadbeef" } of
+        Left err -> assertFailure ("buildingMinting failed with error: " <> err)
+        Right _ -> pure ()
+
+  , testCase "MintingBuilder fails if currency symbol can't be found" $
+      case buildMinting singleMint{ mbMintingCS = Just "beefbeef" } of
+        Left _ -> pure ()
+        Right _ -> assertFailure ("buildMinting should fail if an invalid CS is"
+          <> " passed, but it succeeded.")
+
+  , testCase "MintingBuilder fails with zero inputs" $
+      case buildMinting mempty of
+        Left _ -> pure ()
+        Right _ ->
+          assertFailure ("buildMinting should fail when mbMintingCS,"
+          <> " but it passed.")
+
+  , testCase "MintingBuilder works with either of two Minting CS's" $
+      case buildMinting doubleMint{ mbMintingCS = Just "deadbeef" } of
+        Left err -> assertFailure ("buildMinting failed with error " <> err)
+        Right _ -> case buildMinting doubleMint{ mbMintingCS = Just "bebe" } of
+          Left err -> assertFailure ("buildMinting failed with error " <> err)
+          Right _ -> pure ()
+  ]
+
+singleMint :: MintingBuilder
+singleMint = mint (Value.singleton "deadbeef" "alivecow" 1)
+
+doubleMint :: MintingBuilder
+doubleMint = singleMint <> mint (Value.singleton "bebe" "smallcow" 1)

--- a/sample/MintingBuilder.hs
+++ b/sample/MintingBuilder.hs
@@ -1,6 +1,6 @@
 module MintingBuilder (specs) where
 
-import Plutarch.Context (MintingBuilder (mbMintingCS), buildMinting, mint)
+import Plutarch.Context (MintingBuilder, buildMinting, mint, withMinting)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
 
@@ -11,18 +11,18 @@ specs =
     testGroup
         "Minting Builder Unit Tests"
         [ testCase "MintingBuilder succeeds with single input" $
-            case buildMinting singleMint{mbMintingCS = Just "deadbeef"} of
+            case buildMinting $ withMinting "deadbeef" singleMint of
                 Left err -> assertFailure ("buildingMinting failed with error: " <> err)
                 Right _ -> pure ()
         , testCase "MintingBuilder fails if currency symbol can't be found" $
-            case buildMinting singleMint{mbMintingCS = Just "beefbeef"} of
+            case buildMinting $ withMinting "beefbeef" singleMint of
                 Left _ -> pure ()
                 Right _ ->
                     assertFailure
-                        ( "buildMinting should fail if an invalid CS is"
+                        ( "buildMinting should fail invalid CS is"
                             <> " passed, but it succeeded."
                         )
-        , testCase "MintingBuilder fails with zero inputs" $
+        , testCase "MintingBuilder fails with unspecified currency symbol" $
             case buildMinting mempty of
                 Left _ -> pure ()
                 Right _ ->
@@ -31,9 +31,9 @@ specs =
                             <> " but it passed."
                         )
         , testCase "MintingBuilder works with either of two Minting CS's" $
-            case buildMinting doubleMint{mbMintingCS = Just "deadbeef"} of
+            case buildMinting $ withMinting "deadbeef" doubleMint of
                 Left err -> assertFailure ("buildMinting failed with error " <> err)
-                Right _ -> case buildMinting doubleMint{mbMintingCS = Just "bebe"} of
+                Right _ -> case buildMinting $ withMinting "bebe" doubleMint of
                     Left err -> assertFailure ("buildMinting failed with error " <> err)
                     Right _ -> pure ()
         ]

--- a/sample/MintingBuilder.hs
+++ b/sample/MintingBuilder.hs
@@ -1,39 +1,42 @@
 module MintingBuilder (specs) where
 
+import Plutarch.Context (MintingBuilder (mbMintingCS), buildMinting, mint)
 import Test.Tasty (TestTree, testGroup)
-import Plutarch.Context (mint, buildMinting, MintingBuilder (mbMintingCS))
-import Test.Tasty.HUnit (testCase, assertFailure)
+import Test.Tasty.HUnit (assertFailure, testCase)
 
 import qualified PlutusLedgerApi.V1.Value as Value
 
-
 specs :: TestTree
-specs = testGroup "Minting Builder Unit Tests"
-  [ testCase "MintingBuilder succeeds with single input" $
-      case buildMinting singleMint{ mbMintingCS = Just "deadbeef" } of
-        Left err -> assertFailure ("buildingMinting failed with error: " <> err)
-        Right _ -> pure ()
-
-  , testCase "MintingBuilder fails if currency symbol can't be found" $
-      case buildMinting singleMint{ mbMintingCS = Just "beefbeef" } of
-        Left _ -> pure ()
-        Right _ -> assertFailure ("buildMinting should fail if an invalid CS is"
-          <> " passed, but it succeeded.")
-
-  , testCase "MintingBuilder fails with zero inputs" $
-      case buildMinting mempty of
-        Left _ -> pure ()
-        Right _ ->
-          assertFailure ("buildMinting should fail when mbMintingCS,"
-          <> " but it passed.")
-
-  , testCase "MintingBuilder works with either of two Minting CS's" $
-      case buildMinting doubleMint{ mbMintingCS = Just "deadbeef" } of
-        Left err -> assertFailure ("buildMinting failed with error " <> err)
-        Right _ -> case buildMinting doubleMint{ mbMintingCS = Just "bebe" } of
-          Left err -> assertFailure ("buildMinting failed with error " <> err)
-          Right _ -> pure ()
-  ]
+specs =
+    testGroup
+        "Minting Builder Unit Tests"
+        [ testCase "MintingBuilder succeeds with single input" $
+            case buildMinting singleMint{mbMintingCS = Just "deadbeef"} of
+                Left err -> assertFailure ("buildingMinting failed with error: " <> err)
+                Right _ -> pure ()
+        , testCase "MintingBuilder fails if currency symbol can't be found" $
+            case buildMinting singleMint{mbMintingCS = Just "beefbeef"} of
+                Left _ -> pure ()
+                Right _ ->
+                    assertFailure
+                        ( "buildMinting should fail if an invalid CS is"
+                            <> " passed, but it succeeded."
+                        )
+        , testCase "MintingBuilder fails with zero inputs" $
+            case buildMinting mempty of
+                Left _ -> pure ()
+                Right _ ->
+                    assertFailure
+                        ( "buildMinting should fail when mbMintingCS,"
+                            <> " but it passed."
+                        )
+        , testCase "MintingBuilder works with either of two Minting CS's" $
+            case buildMinting doubleMint{mbMintingCS = Just "deadbeef"} of
+                Left err -> assertFailure ("buildMinting failed with error " <> err)
+                Right _ -> case buildMinting doubleMint{mbMintingCS = Just "bebe"} of
+                    Left err -> assertFailure ("buildMinting failed with error " <> err)
+                    Right _ -> pure ()
+        ]
 
 singleMint :: MintingBuilder
 singleMint = mint (Value.singleton "deadbeef" "alivecow" 1)

--- a/src/Plutarch/Context.hs
+++ b/src/Plutarch/Context.hs
@@ -32,6 +32,7 @@ module Plutarch.Context (
     S.buildSpending,
     S.buildSpendingUnsafe,
     M.MintingBuilder (..),
+    M.withMinting,
     M.buildMinting,
     M.buildMintingUnsafe,
     T.spends,

--- a/src/Plutarch/Context/Minting.hs
+++ b/src/Plutarch/Context/Minting.hs
@@ -17,6 +17,9 @@ module Plutarch.Context.Minting (
     -- * Types
     MintingBuilder (..),
 
+    -- * Input
+    withMinting,
+
     -- * builder
     buildMinting,
     buildMintingUnsafe,
@@ -81,6 +84,9 @@ instance Builder MintingBuilder where
     pack = flip MB Nothing
     unpack = mbInner
 
+withMinting :: CurrencySymbol -> MintingBuilder -> MintingBuilder
+withMinting cs (MB inner _) = MB inner $ Just cs
+
 {- | Builds @ScriptContext@ according to given configuration and
  @MintingBuilder@.
 
@@ -120,7 +126,7 @@ buildMinting builder = flip runContT Right $
 
             case mintingInfo of
                 [] -> lift $ Left "Minting CS not found"
-                (_ : _) -> return $ ScriptContext txinfo (Minting mintingCS)
+                _ -> return $ ScriptContext txinfo (Minting mintingCS)
 
 -- | Builds minting context; it throwing error when builder fails.
 buildMintingUnsafe ::

--- a/src/Plutarch/Context/Minting.hs
+++ b/src/Plutarch/Context/Minting.hs
@@ -49,7 +49,7 @@ import PlutusLedgerApi.V1.Contexts (
 import PlutusLedgerApi.V1.Value (
     CurrencySymbol,
     flattenValue,
-    )
+ )
 
 {- | A context builder for Minting. Corresponds to
  'Plutus.V1.Ledger.Contexts.Minting' specifically.
@@ -94,32 +94,33 @@ buildMinting ::
     MintingBuilder ->
     Either String ScriptContext
 buildMinting builder = flip runContT Right $
-  case mbMintingCS builder of
-    Nothing -> lift $ Left "No minting currency symbol specified"
-    Just mintingCS -> do
-        let bb = unpack builder
+    case mbMintingCS builder of
+        Nothing -> lift $ Left "No minting currency symbol specified"
+        Just mintingCS -> do
+            let bb = unpack builder
 
-        (ins, inDat) <- yieldInInfoDatums (bbInputs bb) builder
-        (outs, outDat) <- yieldOutDatums (bbOutputs bb)
-        mintedValue <- yieldMint (bbMints bb)
-        extraDat <- yieldExtraDatums (bbDatums bb)
-        base <- yieldBaseTxInfo builder
+            (ins, inDat) <- yieldInInfoDatums (bbInputs bb) builder
+            (outs, outDat) <- yieldOutDatums (bbOutputs bb)
+            mintedValue <- yieldMint (bbMints bb)
+            extraDat <- yieldExtraDatums (bbDatums bb)
+            base <- yieldBaseTxInfo builder
 
-        let txinfo =
-                base
-                    { txInfoInputs = ins
-                    , txInfoOutputs = outs
-                    , txInfoData = inDat <> outDat <> extraDat
-                    , txInfoMint = mintedValue
-                    , txInfoSignatories = toList $ bbSignatures bb
-                    }
-            mintingInfo = filter
-              (\(cs, _, _) -> cs == mintingCS )
-              $ flattenValue mintedValue
+            let txinfo =
+                    base
+                        { txInfoInputs = ins
+                        , txInfoOutputs = outs
+                        , txInfoData = inDat <> outDat <> extraDat
+                        , txInfoMint = mintedValue
+                        , txInfoSignatories = toList $ bbSignatures bb
+                        }
+                mintingInfo =
+                    filter
+                        (\(cs, _, _) -> cs == mintingCS)
+                        $ flattenValue mintedValue
 
-        case mintingInfo of
-          [] -> lift $ Left "Minting CS not found"
-          (_ : _ ) -> return $ ScriptContext txinfo (Minting mintingCS)
+            case mintingInfo of
+                [] -> lift $ Left "Minting CS not found"
+                (_ : _) -> return $ ScriptContext txinfo (Minting mintingCS)
 
 -- | Builds minting context; it throwing error when builder fails.
 buildMintingUnsafe ::


### PR DESCRIPTION
Adds the ability to make `ScriptContext`s with the `Minting` `ScriptPurpose`, even if multiple currency symbols appear in the builder.