### PR TITLE
fix checker for `TxId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.5.0 -- 2020-09-26
+
+### Modified
+
+* `checkBSLength` replaced old `checkByteString`. It checks if `ByteString` is
+  at given length.
+
+### Fixed
+
+* `checkTxId` is fixed to follow the new ledger spec and will now look for 32
+  bytes long `ByteString`.
+
 ## 2.4.0 -- 2020-09-14
 
 ### Added

--- a/plutarch-context-builder.cabal
+++ b/plutarch-context-builder.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-context-builder
-version:            2.4.0
+version:            2.5.0
 synopsis:           A builder for ScriptContexts
 description:
   Defines a builder for ScriptContexts, with helpers for commonly-needed uses.
@@ -14,7 +14,7 @@ license:
 -- license-file:       LICENSE
 author:             Koz Ross, Seungheon Oh
 maintainer:
-  Koz Ross <koz@mlabs.city>, Seungheon Oh <seungheon.ooh@gmail.com>  
+  Koz Ross <koz@mlabs.city>, Seungheon Oh <seungheon.ooh@gmail.com>
 
 copyright:          (C) 2022 Liqwid Labs
 category:           Plutarch

--- a/src/Plutarch/Context.hs
+++ b/src/Plutarch/Context.hs
@@ -79,7 +79,7 @@ module Plutarch.Context (
   C.checkIfWith,
   C.checkBool,
   C.checkWith,
-  C.checkByteString,
+  C.checkBSLength,
   C.checkPositiveValue,
   C.checkTxId,
   C.handleErrors,

--- a/src/Plutarch/Context/Check.hs
+++ b/src/Plutarch/Context/Check.hs
@@ -18,7 +18,7 @@ module Plutarch.Context.Check (
   checkFail,
   checkBool,
   checkWith,
-  checkByteString,
+  checkBSLength,
   checkPositiveValue,
   checkTxId,
   checkSignatures,
@@ -270,8 +270,8 @@ checkIfWith f err = Checker $ \y ->
 
  @since 2.1.0
 -}
-checkByteString :: Checker e BuiltinByteString
-checkByteString = checkWith $ \x -> contramap lengthOfByteString $ checkIf (== 28) (IncorrectByteString $ LedgerBytes x)
+checkBSLength :: Int -> Checker e BuiltinByteString
+checkBSLength len = checkWith $ \x -> contramap lengthOfByteString $ checkIf (== toInteger len) (IncorrectByteString $ LedgerBytes x)
 
 {- | Check if all tokens in `Value` are positive.
 
@@ -293,7 +293,7 @@ checkValueNormalized =
     isNormalized val = getValue (normalizeValue val) == getValue val
 
 checkCredential :: Checker e Credential
-checkCredential = contramap classif checkByteString
+checkCredential = contramap classif $ checkBSLength 28
   where
     classif (PubKeyCredential (PubKeyHash x)) = x
     classif (ScriptCredential (ValidatorHash x)) = x
@@ -320,7 +320,7 @@ checkValidatorRedeemer =
 checkTxId :: Builder a => Checker e a
 checkTxId =
   checkAt AtTxId $
-    contramap (getTxId . bbTxId . unpack) checkByteString
+    contramap (getTxId . bbTxId . unpack) (checkBSLength 32)
 
 {- | Check if atleast one signature exists and all follows the format.
 
@@ -330,7 +330,7 @@ checkSignatures :: Builder a => Checker e a
 checkSignatures =
   checkAt AtSignatories $
     mconcat
-      [ contramap (fmap getPubKeyHash . bbSignatures . unpack) (checkFoldable checkByteString)
+      [ contramap (fmap getPubKeyHash . bbSignatures . unpack) (checkFoldable $ checkBSLength 28)
       , contramap (length . bbSignatures . unpack) (checkIf (>= 1) NoSignature)
       ]
 
@@ -373,7 +373,7 @@ checkInputs =
         mconcat
           [ contramap -- TODO: we should have `checkMaybe` here.
               (fmap (getTxId . fromMaybe "" . utxoTxId) . bbInputs . unpack)
-              (checkFoldable checkByteString)
+              (checkFoldable $ checkBSLength 28)
           , contramap
               (getDups . toList . fmap (fromMaybe 0 . utxoTxIdx) . bbInputs . unpack)
               (checkWith $ const $ checkIfWith null DuplicateTxOutRefIndex)

--- a/src/Plutarch/Context/Check.hs
+++ b/src/Plutarch/Context/Check.hs
@@ -266,7 +266,7 @@ checkIfWith f err = Checker $ \y ->
     then mempty
     else basicError $ err y
 
-{- | Verify on-chain bytestring, which as to be 28 in length.
+{- | Verify on-chain bytestring if it matches the given length
 
  @since 2.1.0
 -}


### PR DESCRIPTION
Ledger spec changed. It now uses 32 bytes long ByteString

close #31