### PR TITLE
Fix checkers

### DIFF
--- a/src/Plutarch/Context/Check.hs
+++ b/src/Plutarch/Context/Check.hs
@@ -383,7 +383,7 @@ checkInputs =
         mconcat
           [ contramap -- TODO: we should have `checkMaybe` here.
               (fmap (getTxId . fromMaybe "" . view #txId) . view #inputs . unpack)
-              (checkFoldable $ checkBSLength 28)
+              (checkFoldable $ checkBSLength 32)
           , contramap
               (getDups . toList . fmap (fromMaybe 0 . view #txIdx) . view #inputs . unpack)
               (checkWith $ const $ checkIfWith null DuplicateTxOutRefIndex)

--- a/src/Plutarch/Context/Check.hs
+++ b/src/Plutarch/Context/Check.hs
@@ -426,7 +426,7 @@ checkMints =
     nullAda :: Checker e Value
     nullAda = checkWith $ \x ->
       contramap
-        (all (\(cs, tk, _) -> cs /= adaSymbol && tk /= adaToken) . flattenValue)
+        (all (\(cs, tk, a) -> cs /= adaSymbol || tk /= adaToken || a == 0) . flattenValue)
         (checkBool $ MintingAda x)
 
 {- | Check if fee amount is valid.


### PR DESCRIPTION
Fixes two bugs in checkers.
* Like #32 fixed length check of `TxId`, this one does that for `InputOutRef`
* Second bug was introduced in 465056fe where `mintToValue` returns additional 0 Ada but checker for Mints does not expect that.