### PR TITLE
continuing and continuingWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.6.1 -- 2022-10-20
+
+### Added
+
+* `continuing` and `continuingWith`, allowing easy continuing of 'Value'.
+
 ## 2.6.0 -- 2022-09-27
 
 ### Modified

--- a/plutarch-context-builder.cabal
+++ b/plutarch-context-builder.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-context-builder
-version:            2.6.0
+version:            2.6.1
 synopsis:           A builder for ScriptContexts
 description:
   Defines a builder for ScriptContexts, with helpers for commonly-needed uses.

--- a/src/Plutarch/Context.hs
+++ b/src/Plutarch/Context.hs
@@ -15,6 +15,8 @@ module Plutarch.Context (
   B.address,
   B.input,
   B.referenceInput,
+  B.continuing,
+  B.continuingWith,
   B.credential,
   B.pubKey,
   B.script,

--- a/src/Plutarch/Context/Base.hs
+++ b/src/Plutarch/Context/Base.hs
@@ -24,6 +24,8 @@ module Plutarch.Context.Base (
   -- * Modular constructors
   output,
   input,
+  continuing,
+  continuingWith,
   referenceInput,
   address,
   credential,
@@ -783,6 +785,51 @@ referenceInput ::
   a
 referenceInput x =
   pack . set #referenceInputs (pure x) $ (mempty :: BaseBuilder)
+
+{- | As 'continuingWith', but assumes the \'continued\' 'Value' does not change.
+ Useful for state tokens.
+
+ @since 2.6.1
+-}
+continuing ::
+  forall (a :: Type).
+  (Builder a, Semigroup a) =>
+  -- | How the continued 'UTXO' should transform from input to output
+  (UTXO -> UTXO) ->
+  -- | Input 'UTXO'
+  UTXO ->
+  -- | 'Value' to continue through
+  Value ->
+  a
+continuing = continuingWith id
+
+{- | Specify that a 'UTXO' 'Value' should \'continue\'. More precisely, this
+ acts as a combination of 'input' and 'output', where a \'Value\' is supposed
+ to \'continue through\', possibly with modifications along the way. This also
+ assumes that the input itself continues through, again, possibly with
+ modifications.
+
+ This function is designed to be maximally general. If you don't need the
+ continued 'Value' to change, use 'continuing'; if you don't need the rest
+ of the UTXO to change in the output, pass 'id'.
+
+ @since 2.6.1
+-}
+continuingWith ::
+  forall (a :: Type).
+  (Builder a, Semigroup a) =>
+  -- | How the continued 'Value' should transform from input to output
+  (Value -> Value) ->
+  -- | How the continued 'UTXO' should transform from input to output
+  (UTXO -> UTXO) ->
+  -- | Input 'UTXO'
+  UTXO ->
+  -- | 'Value' to continue through
+  Value ->
+  a
+continuingWith deltaV deltaU inUTXO val =
+  input (withValue val <> inUTXO)
+    <> output (withValue (deltaV val) <> deltaU inUTXO)
 
 {- | Provide base @TxInfo@ to Continuation Monad.
 

--- a/src/Plutarch/Context/Base.hs
+++ b/src/Plutarch/Context/Base.hs
@@ -813,6 +813,13 @@ continuing = continuingWith id
  continued 'Value' to change, use 'continuing'; if you don't need the rest
  of the UTXO to change in the output, pass 'id'.
 
+ = Note
+
+ The 'Value' transformation function will affect only the continued 'Value';
+ thus, if the UTXO was built with additional 'withValue's, those will not be
+ affected by the application of the 'Value' transformation function between
+ input and output.
+
  @since 2.6.1
 -}
 continuingWith ::


### PR DESCRIPTION
Frequently, when writing context builders for cases where state tokens are needed, you need to do something similar to:

```(output $ withValue stateToken <> utxo) <> (input $ withValue stateToken <> f utxo)```

This is annoying to do, and easy to forget, especially if the `Value` being passed through changes.

`continuing` and `continuingWith` encapsulate this pattern, while giving some control over both the `UTXO` and the `Value` associated with it in such a construction. With these, the above example would reduce to

```continuing f utxo stateToken```

We also provide `continuingWith` which takes a `Value -> Value` to apply for the output 'end'.