### PR TITLE
add withdrawal logic

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 2.7.0 -- 2022-11-11
+
+Added "withdrawal" capabilities.
+
+### Added
+
+* Added a `withdrawal :: Builder a => StakingCredential -> Integer -> a` function to 
+  `Plutarch.Context`. 
+
+### Modified 
+
+* Added a `withdrawals` field to the base builder, along with updating the relevant
+  optics.
+
 ## 2.6.2 -- 2022-11-1
 
 ### Modified

--- a/plutarch-context-builder.cabal
+++ b/plutarch-context-builder.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch-context-builder
-version:            2.6.2
+version:            2.7.0
 synopsis:           A builder for ScriptContexts
 description:
   Defines a builder for ScriptContexts, with helpers for commonly-needed uses.

--- a/sample/Main.hs
+++ b/sample/Main.hs
@@ -27,6 +27,7 @@ import Plutarch.Context (
   withSpendingUTXO,
   withStakingCredential,
   withValue,
+  withdrawal,
  )
 import PlutusLedgerApi.V1 (getValue)
 import PlutusLedgerApi.V1.Value (AssetClass (AssetClass), assetClassValueOf)
@@ -35,7 +36,7 @@ import PlutusLedgerApi.V2 (
   Credential (PubKeyCredential),
   PubKeyHash (PubKeyHash),
   ScriptContext (scriptContextTxInfo),
-  StakingCredential (StakingPtr),
+  StakingCredential (StakingHash, StakingPtr),
   TxInfo (txInfoOutputs),
   TxOut (txOutValue),
   Value (Value),
@@ -43,6 +44,7 @@ import PlutusLedgerApi.V2 (
   adaToken,
   fromList,
   singleton,
+  txInfoWdrl,
  )
 import PlutusTx.AssocMap qualified as AssocMap
 
@@ -116,6 +118,11 @@ main = do
                     )
                   ]
               )
+    , testCase
+        "adding a withdrawal has the expected behavior when building a Txinfo"
+        $ let stakingCred = StakingHash $ PubKeyCredential "abcd"
+           in txInfoWdrl (buildTxInfo (withdrawal stakingCred 1))
+                @?= fromList [(stakingCred, 1)]
     ]
   where
     a = buildMinting mempty (mkNormalized $ generalSample <> withMinting "aaaa")

--- a/src/Plutarch/Context.hs
+++ b/src/Plutarch/Context.hs
@@ -38,6 +38,7 @@ module Plutarch.Context (
   B.txId,
   B.fee,
   B.unpack,
+  B.withdrawal,
   B.timeRange,
   B.mkOutRefIndices,
   B.combinePair,

--- a/src/Plutarch/Context/Minting.hs
+++ b/src/Plutarch/Context/Minting.hs
@@ -66,7 +66,8 @@ import PlutusLedgerApi.V2 (
     txInfoOutputs,
     txInfoRedeemers,
     txInfoReferenceInputs,
-    txInfoSignatories
+    txInfoSignatories,
+    txInfoWdrl
   ),
   Value,
   fromList,
@@ -150,6 +151,7 @@ buildMinting' builder@(unpack -> bb) =
           , txInfoMint = mintedValue
           , txInfoRedeemers = fromList $ toList (view #redeemers bb) <> redeemerMap
           , txInfoSignatories = toList . view #signatures $ bb
+          , txInfoWdrl = fromList $ toList (view #withdrawals bb)
           }
       mintcs = case view #mintingCS builder of
         Just cs ->

--- a/src/Plutarch/Context/Spending.hs
+++ b/src/Plutarch/Context/Spending.hs
@@ -64,7 +64,8 @@ import PlutusLedgerApi.V2 (
     txInfoOutputs,
     txInfoRedeemers,
     txInfoReferenceInputs,
-    txInfoSignatories
+    txInfoSignatories,
+    txInfoWdrl
   ),
   TxOutRef (..),
   fromList,
@@ -206,7 +207,6 @@ buildSpending' builder@(unpack -> bb) =
       extraDat = yieldExtraDatums . view #datums $ bb
       base = yieldBaseTxInfo builder
       redeemerMap = yieldRedeemerMap (view #inputs bb) (view #mints bb)
-
       txinfo =
         base
           { txInfoInputs = ins
@@ -216,6 +216,7 @@ buildSpending' builder@(unpack -> bb) =
           , txInfoMint = mintedValue
           , txInfoSignatories = toList . view #signatures $ bb
           , txInfoRedeemers = fromList $ toList (view #redeemers bb) <> redeemerMap
+          , txInfoWdrl = fromList $ toList (view #withdrawals bb)
           }
       vInRef = case view #validatorInput builder >>= yieldValidatorInput ins of
         Nothing -> TxOutRef "" 0

--- a/src/Plutarch/Context/TxInfo.hs
+++ b/src/Plutarch/Context/TxInfo.hs
@@ -41,7 +41,8 @@ import PlutusLedgerApi.V2 (
     txInfoOutputs,
     txInfoRedeemers,
     txInfoReferenceInputs,
-    txInfoSignatories
+    txInfoSignatories,
+    txInfoWdrl
   ),
   fromList,
  )
@@ -84,6 +85,7 @@ buildTxInfo (unpack -> builder) =
           , txInfoMint = mintedValue
           , txInfoSignatories = toList (view #signatures builder)
           , txInfoRedeemers = fromList $ toList (view #redeemers builder) <> redeemerMap
+          , txInfoWdrl = fromList $ toList (view #withdrawals builder)
           }
    in txinfo
 


### PR DESCRIPTION
Adds `withdrawal` to TxInfo, Minting, and Spending builders.

very MVP -- checks aren't written and we don't add a `rewarding` context. These can be saved for the eventual PCB update.